### PR TITLE
create workflow template for functional tests

### DIFF
--- a/argo/workflows/functional-test.yaml
+++ b/argo/workflows/functional-test.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: functional-test
+
+spec:
+  entrypoint: functional-test
+  templates:
+    - name: functional-tests
+      container:
+        image: eu.gcr.io/sbat-gcr-develop/obri/api-tests
+        command: [bash]
+        env:
+          - name: DOMAIN
+            valueFrom:
+              configMapKeyRef:
+                name: domains
+                key: dev
+        source: |
+          #!/bin/bash
+
+          gradle cleanTest test


### PR DESCRIPTION
Create a workflow template for the functional tests.

It will pickup the domain from a configMap, that is generated when the environment is created.