### PR TITLE
optional wildcard cert with namespace setup

### DIFF
--- a/cluster-setup/namespace-setup/templates/wildcard-secret.yaml
+++ b/cluster-setup/namespace-setup/templates/wildcard-secret.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.externalCert.enabled }}
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.externalCert.secretName }}
+  annotations:
+    "helm.sh/hook": pre-install
+spec:
+  backendType: gcpSecretsManager
+  template:
+    type: kubernetes.io/tls
+  projectId: {{ .Values.externalCert.projectId }}
+  data:
+    - key: wildcard-crt
+      name: tls.crt
+      version: latest
+    - key: wildcard-key
+      name: tls.key
+      version: latest
+{{- end }}

--- a/cluster-setup/namespace-setup/values.yaml
+++ b/cluster-setup/namespace-setup/values.yaml
@@ -3,3 +3,8 @@ serviceAccount: default
 imageRepoSecret:
   namespace: default
   name: gcr-secret
+
+externalCert:
+  enabled: true
+  projectId: example-project
+  secretName: sslcert


### PR DESCRIPTION
Add optional wildcard when a namespace is created. This will bring it down from the secrets manager and prevent cert manager for breaking out environment.