### PR TITLE
add parameter configuration for pipelines

### DIFF
--- a/argo/apps/templates/namespace-init.yaml
+++ b/argo/apps/templates/namespace-init.yaml
@@ -12,6 +12,10 @@ spec:
     server: {{ .Values.spec.destination.server }}
   project: {{ .Values.spec.project }}
   source:
+    helm:
+      parameters:
+      - name: externalCert.projectId
+        value: {{ .Values.config.externalCert.projectId }}
     path: cluster-setup/namespace-setup
     repoURL: https://github.com/SecureBankingAccessToolkit/init-charts
     targetRevision: {{ .Values.spec.source.targetRevision }}

--- a/argo/apps/templates/securebanking-rcs.yaml
+++ b/argo/apps/templates/securebanking-rcs.yaml
@@ -10,6 +10,10 @@ spec:
     server: {{ .Values.spec.destination.server }}
   project: {{ .Values.spec.project }}
   source:
+    helm:
+      parameters:
+      - name: ingress.domain
+        value: {{ .Values.config.domain }}
     path: _infra/helm/securebanking-openbanking-uk-rcs
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-rcs
     targetRevision: {{ .Values.spec.source.targetRevision }}

--- a/argo/apps/templates/securebanking-rs.yaml
+++ b/argo/apps/templates/securebanking-rs.yaml
@@ -10,6 +10,10 @@ spec:
     server: {{ .Values.spec.destination.server }}
   project: {{ .Values.spec.project }}
   source:
+    helm:
+      parameters:
+      - name: ingress.domain
+        value: {{ .Values.config.domain }}
     path: _infra/helm/securebanking-openbanking-uk-rs
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-rs
     targetRevision: {{ .Values.spec.source.targetRevision }}

--- a/argo/apps/values.yaml
+++ b/argo/apps/values.yaml
@@ -8,3 +8,8 @@ spec:
     targetRevision: HEAD
 
   syncPolicy: {}
+
+config:
+  domain: localhost
+  externalCert:
+    projectId: example-project


### PR DESCRIPTION
Let our argo pipelines define its own config overrides for obfuscated config. both the domain name of the developer environment and the the GCP project name that stores the external certificates.

https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-rs/issues/40