### PR TITLE
namespace apps and all destroying of namesapces in workflows

### DIFF
--- a/argo/apps/templates/mongodb.yaml
+++ b/argo/apps/templates/mongodb.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: mongodb
+  name: mongodb-{{ .Release.Name }}
 spec:
   destination:
     namespace: {{ .Values.spec.destination.namespace }}

--- a/argo/apps/templates/namespace-init.yaml
+++ b/argo/apps/templates/namespace-init.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: namespace-setup
+  name: namespace-setup-{{ .Release.Name }}
   annotations:
     argocd.argoproj.io/hook: PreSync
   finalizers:

--- a/argo/apps/templates/securebaking-spring-config-server.yaml
+++ b/argo/apps/templates/securebaking-spring-config-server.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: securebanking-spring-config-server
+  name: securebanking-spring-config-server-{{ .Release.Name }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argo/apps/templates/securebanking-rcs.yaml
+++ b/argo/apps/templates/securebanking-rcs.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: securebanking-rcs
+  name: securebanking-rcs-{{ .Release.Name }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argo/apps/templates/securebanking-rs.yaml
+++ b/argo/apps/templates/securebanking-rs.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: securebanking-rs
+  name: securebanking-rs-{{ .Release.Name }}
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argo/workflows/environment-creation.yaml
+++ b/argo/workflows/environment-creation.yaml
@@ -4,47 +4,82 @@ metadata:
   name: create-environment
 spec:
   entrypoint: create-environment
+  arguments:
+    parameters:
+      - name: clean
+        value: false
+      - name: namespace
+        value: dev
 
   templates:
   - name: create-environment
     # Instead of just running a container
     # This template has a sequence of steps
     steps:
+    - - name: clean
+        template: clean
+        arguments:
+          parameters:
+          - name: namespace
+            value: "{{workflow.parameters.namespace}}"
+        when: "{{workflow.parameters.clean}}"
     - - name: init-namespace
         template: sync-git
         arguments:
           parameters:
           - name: application-name
             value: namespace-setup
+          - name: namespace
+            value: "{{workflow.parameters.namespace}}"
     - - name: Mongodb
         template: sync-helm
         arguments:
           parameters:
           - name: application-name
             value: mongodb
+          - name: namespace
+            value: "{{workflow.parameters.namespace}}"
       - name: securebanking-spring-config-server
         template: sync-git
         arguments:
           parameters:
           - name: application-name
             value: securebanking-spring-config-server
+          - name: namespace
+            value: "{{workflow.parameters.namespace}}"
     - - name: securebanking-rs
         template: sync-git
         arguments:
           parameters:
           - name: application-name
             value: securebanking-rs
+          - name: namespace
+            value: "{{workflow.parameters.namespace}}"
     - - name: securebanking-rcs
         template: sync-git
         arguments:
           parameters:
           - name: application-name
             value: securebanking-rcs
+          - name: namespace
+            value: "{{workflow.parameters.namespace}}"
   
+  - name: clean
+    inputs:
+      parameters:
+      - name: namespace
+    container:
+      image: eu.gcr.io/sbat-gcr-develop/ci/gcloud-tools:latest
+      command: [ /bin/bash, -c ]
+      args:
+        - |
+          kubectl delete ns "{{inputs.parameters.namespace}}" --ignore-not-found --wait --force
+
   - name: sync-git
     inputs:
       parameters:
       - name: application-name
+      - name: namespace
     steps:                              # You should only reference external "templates" in a "steps" or "dag" "template".
       - - name: sync
           templateRef:                  # You can reference a "template" from another "WorkflowTemplate or ClusterWorkflowTemplate" using this field
@@ -54,11 +89,14 @@ spec:
             parameters:
             - name: application-name
               value: "{{inputs.parameters.application-name}}"
+            - name: namespace
+              value: "{{inputs.parameters.namespace}}"
   
   - name: sync-helm
     inputs:
       parameters:
       - name: application-name
+      - name: namespace
     steps:                              # You should only reference external "templates" in a "steps" or "dag" "template".
       - - name: sync
           templateRef:                  # You can reference a "template" from another "WorkflowTemplate or ClusterWorkflowTemplate" using this field
@@ -68,3 +106,5 @@ spec:
             parameters:
             - name: application-name
               value: "{{inputs.parameters.application-name}}"
+            - name: namespace
+              value: "{{inputs.parameters.namespace}}"

--- a/argo/workflows/sync-and-wait.yaml
+++ b/argo/workflows/sync-and-wait.yaml
@@ -19,6 +19,7 @@ spec:
       - name: argocd-version
         value: v2.0.0
       - name: application-name
+      - name: namespace
       - name: revision
         value: HEAD
       - name: flags
@@ -42,8 +43,8 @@ spec:
 
         set -euo pipefail
 
-        argocd app sync {{inputs.parameters.application-name}} --revision {{inputs.parameters.revision}} {{inputs.parameters.flags}}
-        argocd app wait {{inputs.parameters.application-name}} --health {{inputs.parameters.flags}}
+        argocd app sync {{inputs.parameters.application-name}}-{{inputs.parameters.namespace}} --revision {{inputs.parameters.revision}} {{inputs.parameters.flags}}
+        argocd app wait {{inputs.parameters.application-name}}-{{inputs.parameters.namespace}} --health {{inputs.parameters.flags}}
   
   - name: sync-helm
     inputs:
@@ -51,6 +52,7 @@ spec:
       - name: argocd-version
         value: v2.0.0
       - name: application-name
+      - name: namespace
       - name: flags
         value: --
     script:
@@ -72,5 +74,5 @@ spec:
 
         set -euo pipefail
         
-        argocd app sync {{inputs.parameters.application-name}} {{inputs.parameters.flags}}
-        argocd app wait {{inputs.parameters.application-name}} --health {{inputs.parameters.flags}}
+        argocd app sync {{inputs.parameters.application-name}}-{{inputs.parameters.namespace}} {{inputs.parameters.flags}}
+        argocd app wait {{inputs.parameters.application-name}}-{{inputs.parameters.namespace}} --health {{inputs.parameters.flags}}


### PR DESCRIPTION
The argo applications are created each morning via helm. Add a suffix for the namespace they will be created in and supply an additional step in the environment creation that will let you destroy your namespace before creating an environment.
This allows for the quick teardown and rebuild of an enviornment.