### PR TITLE
add sync application pipeline

### DIFF
--- a/argo/workflows/sync-and-wait.yaml
+++ b/argo/workflows/sync-and-wait.yaml
@@ -20,6 +20,8 @@ spec:
         value: v2.0.0
       - name: application-name
       - name: namespace
+      - name: tag
+        value: latest
       - name: revision
         value: HEAD
       - name: flags
@@ -42,7 +44,7 @@ spec:
         #!/bin/bash
 
         set -euo pipefail
-
+        argocd app set {{inputs.parameters.application-name}}-{{inputs.parameters.namespace}} -p deployment.imageOverride.tag={{inputs.parameters.tag}}
         argocd app sync {{inputs.parameters.application-name}}-{{inputs.parameters.namespace}} --revision {{inputs.parameters.revision}} {{inputs.parameters.flags}}
         argocd app wait {{inputs.parameters.application-name}}-{{inputs.parameters.namespace}} --health {{inputs.parameters.flags}}
   

--- a/argo/workflows/sync-application.yaml
+++ b/argo/workflows/sync-application.yaml
@@ -1,0 +1,50 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: sync-application
+spec:
+  entrypoint: sync-application
+  arguments:
+    parameters:
+      - name: namespace
+        value: dev
+      - name: application-name
+      - name: tag
+        value: latest
+
+  templates:
+  - name: sync-application
+    # Instead of just running a container
+    # This template has a sequence of steps
+    steps:
+    - - name: sync-application
+        template: sync-git
+        arguments:
+          parameters:
+          - name: application-name
+            value: "{{workflow.parameters.application-name}}"
+          - name: tag
+            value: "{{workflow.parameters.tag}}"
+          - name: namespace
+            value: "{{workflow.parameters.namespace}}"
+
+  - name: sync-git
+    inputs:
+      parameters:
+      - name: application-name
+      - name: tag
+      - name: namespace
+    steps:                              # You should only reference external "templates" in a "steps" or "dag" "template".
+      - - name: sync
+          templateRef:                  # You can reference a "template" from another "WorkflowTemplate or ClusterWorkflowTemplate" using this field
+            name: argocd-sync-and-wait   # This is the name of the "WorkflowTemplate or ClusterWorkflowTemplate" CRD that contains the "template" you want
+            template: sync-git # This is the name of the "template" you want to reference
+          arguments:                    # You can pass in arguments as normal
+            parameters:
+            - name: application-name
+              value: "{{inputs.parameters.application-name}}"
+            - name: tag
+              value: "{{inputs.parameters.tag}}"
+            - name: namespace
+              value: "{{inputs.parameters.namespace}}"
+  


### PR DESCRIPTION
Allow synchronising of individual applications. This will allow us to deploy applications to kubernetes in the PR phase of a git request while letting us set different docker tags for our apps.