### PR TITLE
start morning build at 8:30

### DIFF
--- a/argo/workflows/morning-dev-sync.yaml
+++ b/argo/workflows/morning-dev-sync.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 1
-  schedule: 0 8 * * MON-FRI
+  schedule: 30 8 * * MON-FRI
   successfulJobsHistoryLimit: 1
   timezone: Europe/London
   workflowSpec:


### PR DESCRIPTION
Set the morning build to trigger half hour later. its currently set to trigger before argo is even created in the morning.
we have to set it to 8:30 as BST is 1 hour ahead of UTC. this will actually trigger at 7:30am.